### PR TITLE
Fix homepage link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description = "Pure-func helps to write pure functions in python",
     long_description = README_TEXT,
     keywords = "pure functional programming unit-testing",
-    url = "http://github.com/adfinis-sygroup/pure-func",
+    url = "http://github.com/adfinis-sygroup/pure_func",
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The one currently on pypi 404s: https://pypi.python.org/pypi/pure-func/1.1 leads to http://github.com/adfinis-sygroup/pure-func which does not exist.